### PR TITLE
update deep-extend to v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
-    "deep-extend": "^0.4.1",
+    "deep-extend": "^0.5.1",
     "mkdirp": "^0.5.1",
     "strip-ansi": "^2.0.1"
   }


### PR DESCRIPTION
fixes CWE-471 (https://nodesecurity.io/advisories/612)

see also https://github.com/owais/webpack-bundle-tracker/pull/32